### PR TITLE
Fix: getMenuNameAttribute is not working in model

### DIFF
--- a/resources/views/livewire/menu-item.blade.php
+++ b/resources/views/livewire/menu-item.blade.php
@@ -7,7 +7,7 @@
                 <x-heroicon-o-arrows-up-down class="w-6 h-6 m-2 handle" />
             </div>
             <div class="ml-2 flex">
-                <span class="font-medium">{{ $item->name }}</span>
+                <span class="font-medium">{{ $item->menu_name }}</span>
                 <x-filament::badge size="xs" class="ml-2 px-2" color="gray">
                     {{ $item->normalized_type }}
                 </x-filament::badge>

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -51,16 +51,17 @@ class MenuItem extends Model
         return $this->belongsTo(Menu::class);
     }
 
-    public function getMenuNameAttribute($value)
+    public function getMenuNameAttribute($value): string
     {
+        $name = $this->attributes['name'];
         if ($this->type->value === 'model' && $this->use_menuable_name) {
-            return $this->menuable->menu_name;
+            $name = $this->menuable?->menu_name;
         }
 
-        return $this->attributes['name'];
+        return $name ?? $this->attributes['name'];
     }
 
-    public function getNormalizedTypeAttribute($value)
+    public function getNormalizedTypeAttribute($value): string
     {
         if ($this->type->value !== 'model') {
             return $this->type->getLabel();


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/Biostate/filament-menu-builder/issues/1).