### PR TITLE
Allow mass-assignment of MenuItem::id

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -34,6 +34,7 @@ class MenuItem extends Model
     use NodeTrait;
 
     protected $fillable = [
+        'id',
         'name',
         'target',
         'type',


### PR DESCRIPTION
I encountered an error when reordering the menu items.
For some reason, saving the reordered items also tries updating the model `id`s.
Even though they don't actually change, they trigger an error when strict models are turned on.

My setup:

```php
<?php

declare(strict_types=1);

namespace App\Providers;

final class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Model::shouldBeStrict();
    }
}
```

The error:

![Screenshot 2025-03-24 at 15 58 55](https://github.com/user-attachments/assets/95734fbf-72d7-41d8-845f-a0f93d69d1da)

I dug around the code in an attempt to remove the `id` attribute from the update query,
however, I failed to find the place where it is executed. The simplest solution was adding
the `id` attribute to the `$fillable` list.