### PR TITLE
Fix: use menu_name accessor for menuable select label (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `filament-menu-builder` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+* Fix null label error in the menuable Select when a model has no `name` column but defines `getMenuNameAttribute()`. The Select options pipeline now uses the `menu_name` accessor for display, while `getFilamentSearchLabel()` remains the database column used for searching. (#23)
+
+### Documentation
+
+* Document `getFilamentSearchLabel()` in the Menuable Trait guide and clarify how it relates to `getMenuNameAttribute()`.
+
 ## v5.0.1 - 2026-02-13
 
 **Full Changelog**: https://github.com/Biostate/filament-menu-builder/compare/v5.0.0...v5.0.1

--- a/config/filament-menu-builder.php
+++ b/config/filament-menu-builder.php
@@ -1,5 +1,8 @@
 <?php
 
+use Biostate\FilamentMenuBuilder\DTO\Menu;
+use Biostate\FilamentMenuBuilder\DTO\MenuItem;
+
 return [
     'models' => [
         // 'Product' => 'App\\Models\\Product',
@@ -24,7 +27,7 @@ return [
         //
     ],
     'dto' => [
-        'menu' => \Biostate\FilamentMenuBuilder\DTO\Menu::class,
-        'menu_item' => \Biostate\FilamentMenuBuilder\DTO\MenuItem::class,
+        'menu' => Menu::class,
+        'menu_item' => MenuItem::class,
     ],
 ];

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -6,7 +6,7 @@ use Biostate\FilamentMenuBuilder\Models\Menu;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Biostate\FilamentMenuBuilder\Models\Menu>
+ * @extends Factory<Menu>
  */
 class MenuFactory extends Factory
 {

--- a/database/factories/MenuItemFactory.php
+++ b/database/factories/MenuItemFactory.php
@@ -3,11 +3,12 @@
 namespace Biostate\FilamentMenuBuilder\Database\Factories;
 
 use Biostate\FilamentMenuBuilder\Enums\MenuItemType;
+use Biostate\FilamentMenuBuilder\Models\Menu;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Biostate\FilamentMenuBuilder\Models\MenuItem>
+ * @extends Factory<MenuItem>
  */
 class MenuItemFactory extends Factory
 {
@@ -33,7 +34,7 @@ class MenuItemFactory extends Factory
             'menuable_id' => null,
             'menuable_type' => null,
             'use_menuable_name' => false,
-            'menu_id' => \Biostate\FilamentMenuBuilder\Models\Menu::factory(),
+            'menu_id' => Menu::factory(),
         ];
     }
 

--- a/docs/menuable-trait.md
+++ b/docs/menuable-trait.md
@@ -43,6 +43,36 @@ class Product extends Model
 }
 ```
 
+## Customizing the Search Column
+
+When users search for a model in the menu item form, the trait builds a `LIKE` query against a real database column. By default that column is `name`. If your model uses a different column (for example `title`), override `getFilamentSearchLabel()`:
+
+```php
+use Biostate\FilamentMenuBuilder\Traits\Menuable;
+
+class Page extends Model
+{
+    use Menuable;
+
+    public function getMenuLinkAttribute(): string
+    {
+        return route('pages.show', $this);
+    }
+
+    public function getMenuNameAttribute(): string
+    {
+        return $this->title;
+    }
+
+    public static function getFilamentSearchLabel(): string
+    {
+        return 'title';
+    }
+}
+```
+
+`getFilamentSearchLabel()` must return the name of an actual database column — it is used in the `WHERE` clause of the search query. The display label shown in the select field comes from `getMenuNameAttribute()`, so the two methods are independent: use `getMenuNameAttribute()` to control how the option is rendered, and `getFilamentSearchLabel()` to control which column the search runs against.
+
 ## Registering Models in Config
 
 After adding the trait to your model, you need to register it in the config file. You can add multiple models:

--- a/src/Filament/Resources/MenuItemResource.php
+++ b/src/Filament/Resources/MenuItemResource.php
@@ -6,12 +6,17 @@ use BackedEnum;
 use Biostate\FilamentMenuBuilder\Contracts\MenuItemResourceInterface;
 use Biostate\FilamentMenuBuilder\Enums\MenuItemTarget;
 use Biostate\FilamentMenuBuilder\Enums\MenuItemType;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\CreateMenuItem;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\EditMenuItem;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\ListMenuItems;
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Actions;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -21,7 +26,7 @@ class MenuItemResource extends Resource implements MenuItemResourceInterface
 {
     public static function getModel(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuItemModel();
+        return FilamentMenuBuilderPlugin::get()->getMenuItemModel();
     }
 
     protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-bars-3';
@@ -89,7 +94,7 @@ class MenuItemResource extends Resource implements MenuItemResourceInterface
                 ->maxLength(255),
             Select::make('menu_id')
                 ->label(__('filament-menu-builder::menu-builder.menu_name'))
-                ->options(fn () => \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuModel()::all()->pluck('name', 'id'))
+                ->options(fn () => FilamentMenuBuilderPlugin::get()->getMenuModel()::all()->pluck('name', 'id'))
                 ->hidden(fn ($context) => ! in_array($context, ['edit', 'create']))
                 ->required(),
             Select::make('target')
@@ -103,7 +108,7 @@ class MenuItemResource extends Resource implements MenuItemResourceInterface
             TextInput::make('wrapper_class')
                 ->label(__('filament-menu-builder::menu-builder.form_labels.wrapper_class'))
                 ->maxLength(255),
-            \Filament\Schemas\Components\Fieldset::make('URL')
+            Fieldset::make('URL')
                 ->columns(1)
                 ->schema([
                     Select::make('type')
@@ -249,9 +254,9 @@ class MenuItemResource extends Resource implements MenuItemResourceInterface
     public static function getPages(): array
     {
         return [
-            'index' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\ListMenuItems::route('/'),
-            'create' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\CreateMenuItem::route('/create'),
-            'edit' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages\EditMenuItem::route('/{record}/edit'),
+            'index' => ListMenuItems::route('/'),
+            'create' => CreateMenuItem::route('/create'),
+            'edit' => EditMenuItem::route('/{record}/edit'),
         ];
     }
 }

--- a/src/Filament/Resources/MenuItemResource.php
+++ b/src/Filament/Resources/MenuItemResource.php
@@ -219,11 +219,11 @@ class MenuItemResource extends Resource implements MenuItemResourceInterface
                     Select::make('menuable_id')
                         ->label(__('filament-menu-builder::menu-builder.form_labels.menuable_id'))
                         ->searchable()
-                        ->options(fn ($get) => $get('menuable_type')::all()->pluck($get('menuable_type')::getFilamentSearchLabel(), 'id'))
+                        ->options(fn ($get) => $get('menuable_type')::all()->mapWithKeys(fn ($model) => [$model->getKey() => $model->getFilamentSearchOptionName()]))
                         ->getSearchResultsUsing(function (string $search, callable $get) {
                             $className = $get('menuable_type');
 
-                            return $className::filamentSearch($search)->pluck($className::getFilamentSearchLabel(), 'id');
+                            return $className::filamentSearch($search)->get()->mapWithKeys(fn ($model) => [$model->getKey() => $model->getFilamentSearchOptionName()]);
                         })
                         ->required(fn ($get) => $get('menuable_type') != null)
                         ->getOptionLabelUsing(fn ($value, $get): ?string => $get('menuable_type')::find($value)?->getFilamentSearchOptionName())

--- a/src/Filament/Resources/MenuItemResource/Pages/CreateMenuItem.php
+++ b/src/Filament/Resources/MenuItemResource/Pages/CreateMenuItem.php
@@ -2,12 +2,13 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateMenuItem extends CreateRecord
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuItemResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuItemResource();
     }
 }

--- a/src/Filament/Resources/MenuItemResource/Pages/EditMenuItem.php
+++ b/src/Filament/Resources/MenuItemResource/Pages/EditMenuItem.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -9,7 +10,7 @@ class EditMenuItem extends EditRecord
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuItemResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuItemResource();
     }
 
     protected function getActions(): array

--- a/src/Filament/Resources/MenuItemResource/Pages/ListMenuItems.php
+++ b/src/Filament/Resources/MenuItemResource/Pages/ListMenuItems.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
@@ -9,7 +10,7 @@ class ListMenuItems extends ListRecords
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuItemResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuItemResource();
     }
 
     protected function getActions(): array

--- a/src/Filament/Resources/MenuResource.php
+++ b/src/Filament/Resources/MenuResource.php
@@ -3,6 +3,11 @@
 namespace Biostate\FilamentMenuBuilder\Filament\Resources;
 
 use BackedEnum;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\CreateMenu;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\EditMenu;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\ListMenus;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\MenuBuilder;
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Biostate\FilamentMenuBuilder\Models\Menu;
 use Filament\Actions;
 use Filament\Forms\Components\TextInput;
@@ -15,7 +20,7 @@ class MenuResource extends Resource
 {
     public static function getModel(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuModel();
+        return FilamentMenuBuilderPlugin::get()->getMenuModel();
     }
 
     protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-bars-3';
@@ -98,10 +103,10 @@ class MenuResource extends Resource
     {
 
         return [
-            'index' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\ListMenus::route('/'),
-            'create' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\CreateMenu::route('/create'),
-            'edit' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\EditMenu::route('/{record}/edit'),
-            'build' => \Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages\MenuBuilder::route('/{record}/build'),
+            'index' => ListMenus::route('/'),
+            'create' => CreateMenu::route('/create'),
+            'edit' => EditMenu::route('/{record}/edit'),
+            'build' => MenuBuilder::route('/{record}/build'),
         ];
     }
 }

--- a/src/Filament/Resources/MenuResource/Pages/CreateMenu.php
+++ b/src/Filament/Resources/MenuResource/Pages/CreateMenu.php
@@ -2,12 +2,13 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateMenu extends CreateRecord
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuResource();
     }
 }

--- a/src/Filament/Resources/MenuResource/Pages/EditMenu.php
+++ b/src/Filament/Resources/MenuResource/Pages/EditMenu.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Biostate\FilamentMenuBuilder\Models\Menu;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
@@ -11,7 +12,7 @@ class EditMenu extends EditRecord
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuResource();
     }
 
     protected function getActions(): array

--- a/src/Filament/Resources/MenuResource/Pages/ListMenus.php
+++ b/src/Filament/Resources/MenuResource/Pages/ListMenus.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
@@ -9,7 +10,7 @@ class ListMenus extends ListRecords
 {
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuResource();
     }
 
     protected function getActions(): array

--- a/src/Filament/Resources/MenuResource/Pages/MenuBuilder.php
+++ b/src/Filament/Resources/MenuResource/Pages/MenuBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource\Pages;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Resources\Pages\Concerns\InteractsWithRecord;
 use Filament\Resources\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
@@ -12,7 +13,7 @@ class MenuBuilder extends Page
 
     public static function getResource(): string
     {
-        return \Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuResource();
+        return FilamentMenuBuilderPlugin::get()->getMenuResource();
     }
 
     public function getTitle(): string | Htmlable

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -84,7 +84,7 @@ class FilamentMenuBuilderPlugin implements Plugin
     }
 
     /**
-     * @return class-string<\Biostate\FilamentMenuBuilder\Contracts\MenuItemResourceInterface>
+     * @return class-string<MenuItemResourceInterface>
      */
     public function getMenuItemResource(): string
     {

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder;
 
+use Biostate\FilamentMenuBuilder\Contracts\MenuItemResourceInterface;
 use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource;
 use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource;
 use Biostate\FilamentMenuBuilder\Models\Menu;
@@ -83,7 +84,7 @@ class FilamentMenuBuilderPlugin implements Plugin
     }
 
     /**
-     * @return class-string<MenuItemResourceInterface>
+     * @return class-string<\Biostate\FilamentMenuBuilder\Contracts\MenuItemResourceInterface>
      */
     public function getMenuItemResource(): string
     {

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -4,9 +4,12 @@ namespace Biostate\FilamentMenuBuilder;
 
 use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource;
 use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource;
+use Biostate\FilamentMenuBuilder\Models\Menu;
+use Biostate\FilamentMenuBuilder\Models\MenuItem;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Model;
 
 class FilamentMenuBuilderPlugin implements Plugin
 {
@@ -14,9 +17,9 @@ class FilamentMenuBuilderPlugin implements Plugin
 
     protected string $menuItemResource = MenuItemResource::class;
 
-    protected string $menuModel = \Biostate\FilamentMenuBuilder\Models\Menu::class;
+    protected string $menuModel = Menu::class;
 
-    protected string $menuItemModel = \Biostate\FilamentMenuBuilder\Models\MenuItem::class;
+    protected string $menuItemModel = MenuItem::class;
 
     public function getId(): string
     {
@@ -80,7 +83,7 @@ class FilamentMenuBuilderPlugin implements Plugin
     }
 
     /**
-     * @return class-string<\Biostate\FilamentMenuBuilder\Contracts\MenuItemResourceInterface>
+     * @return class-string<MenuItemResourceInterface>
      */
     public function getMenuItemResource(): string
     {
@@ -93,8 +96,8 @@ class FilamentMenuBuilderPlugin implements Plugin
             throw new \InvalidArgumentException("Class {$menuModel} does not exist");
         }
 
-        if (! is_subclass_of($menuModel, \Illuminate\Database\Eloquent\Model::class)) {
-            throw new \InvalidArgumentException("Class {$menuModel} must extend " . \Illuminate\Database\Eloquent\Model::class);
+        if (! is_subclass_of($menuModel, Model::class)) {
+            throw new \InvalidArgumentException("Class {$menuModel} must extend " . Model::class);
         }
 
         $this->menuModel = $menuModel;
@@ -108,8 +111,8 @@ class FilamentMenuBuilderPlugin implements Plugin
             throw new \InvalidArgumentException("Class {$menuItemModel} does not exist");
         }
 
-        if (! is_subclass_of($menuItemModel, \Illuminate\Database\Eloquent\Model::class)) {
-            throw new \InvalidArgumentException("Class {$menuItemModel} must extend " . \Illuminate\Database\Eloquent\Model::class);
+        if (! is_subclass_of($menuItemModel, Model::class)) {
+            throw new \InvalidArgumentException("Class {$menuItemModel} must extend " . Model::class);
         }
 
         $this->menuItemModel = $menuItemModel;

--- a/src/Http/Livewire/MenuBuilder.php
+++ b/src/Http/Livewire/MenuBuilder.php
@@ -13,14 +13,16 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Grid;
 use Filament\Support\Enums\Size;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Kalnoy\Nestedset\QueryBuilder;
 use Livewire\Component;
 
 /**
  * @property int $menuId
  * @property array $data
- * @property \Illuminate\Database\Eloquent\Model $menuItem
- * @property \Illuminate\Database\Eloquent\Model $newMenuItem
+ * @property Model $menuItem
+ * @property Model $newMenuItem
  */
 class MenuBuilder extends Component implements HasActions, HasForms
 {
@@ -244,7 +246,7 @@ class MenuBuilder extends Component implements HasActions, HasForms
 
     public function items(): Collection
     {
-        /** @var \Kalnoy\Nestedset\QueryBuilder $query */
+        /** @var QueryBuilder $query */
         $query = MenuItem::query()
             ->where('menu_id', $this->menuId)
             ->with('menuable');

--- a/src/Http/Livewire/MenuItemForm.php
+++ b/src/Http/Livewire/MenuItemForm.php
@@ -2,8 +2,10 @@
 
 namespace Biostate\FilamentMenuBuilder\Http\Livewire;
 
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource;
 use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
+use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
@@ -14,7 +16,7 @@ use Livewire\Component;
 /**
  * @property int $menuId
  * @property array|null $data
- * @property \Filament\Schemas\Schema $form
+ * @property Schema $form
  */
 class MenuItemForm extends Component implements HasSchemas
 {
@@ -43,7 +45,7 @@ class MenuItemForm extends Component implements HasSchemas
             throw new \RuntimeException('Filament Menu Builder plugin not registered');
         }
 
-        /** @var class-string<\Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource> $menuItemResource */
+        /** @var class-string<MenuItemResource> $menuItemResource */
         $menuItemResource = $plugin->getMenuItemResource();
 
         return $schema
@@ -52,7 +54,7 @@ class MenuItemForm extends Component implements HasSchemas
                     ->description(__('filament-menu-builder::menu-builder.create_new_menu_item'))
                     ->schema($menuItemResource::getFormSchemaArray())
                     ->footerActions([
-                        \Filament\Actions\Action::make('submit')
+                        Action::make('submit')
                             ->label(__('filament-menu-builder::menu-builder.create_menu_item'))
                             ->submit('submit'),
                     ]),

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -2,6 +2,7 @@
 
 namespace Biostate\FilamentMenuBuilder\Models;
 
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -20,7 +21,7 @@ class Menu extends Model
 
     public function items(): HasMany
     {
-        return $this->hasMany(\Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuItemModel());
+        return $this->hasMany(FilamentMenuBuilderPlugin::get()->getMenuItemModel());
     }
 
     /**

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -3,10 +3,12 @@
 namespace Biostate\FilamentMenuBuilder\Models;
 
 use Biostate\FilamentMenuBuilder\Enums\MenuItemType;
+use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -28,7 +30,7 @@ use Kalnoy\Nestedset\NodeTrait;
  * @property-read string $menu_name
  * @property-read string $normalized_type
  * @property-read string $link
- * @property-read \Illuminate\Database\Eloquent\Model|null $menuable
+ * @property-read Model|null $menuable
  * @property-read bool $is_route_resolved
  * @property-read bool $is_url_resolved
  * @property-read bool $is_link_resolved
@@ -80,7 +82,7 @@ class MenuItem extends Model
 
     public function menu(): BelongsTo
     {
-        return $this->belongsTo(\Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getMenuModel());
+        return $this->belongsTo(FilamentMenuBuilderPlugin::get()->getMenuModel());
     }
 
     public function getMenuNameAttribute($value): string
@@ -157,7 +159,7 @@ class MenuItem extends Model
             $this->resolveRoute();
 
             return [];
-        } catch (\Illuminate\Routing\Exceptions\UrlGenerationException $e) {
+        } catch (UrlGenerationException $e) {
             return $this->extractMissingParameters();
         } catch (\Exception $e) {
             return [];
@@ -207,7 +209,7 @@ class MenuItem extends Model
             $this->resolveRoute();
 
             return null;
-        } catch (\Illuminate\Routing\Exceptions\UrlGenerationException $e) {
+        } catch (UrlGenerationException $e) {
             $missingParams = $this->extractMissingParameters();
             if (! empty($missingParams)) {
                 return 'Missing route parameters: ' . implode(', ', $missingParams);

--- a/src/Traits/Menuable.php
+++ b/src/Traits/Menuable.php
@@ -40,6 +40,6 @@ trait Menuable
 
     public function getFilamentSearchOptionName()
     {
-        return $this->{$this->getFilamentSearchLabel()};
+        return $this->menu_name;
     }
 }

--- a/tests/DynamicModelTest.php
+++ b/tests/DynamicModelTest.php
@@ -1,8 +1,12 @@
 <?php
 
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource;
+use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource;
 use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Biostate\FilamentMenuBuilder\Models\Menu;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
+use Filament\Facades\Filament;
+use Filament\Panel;
 
 class CustomMenu extends Menu {}
 class CustomMenuItem extends MenuItem {}
@@ -35,14 +39,14 @@ it('uses dynamic models in resources', function () {
     $plugin->usingMenuItemModel(CustomMenuItem::class);
 
     // Mock the plugin registration in Filament
-    $panel = \Filament\Facades\Filament::getCurrentPanel();
+    $panel = Filament::getCurrentPanel();
     if (! $panel) {
         // Setup a dummy panel if none exists
-        $panel = \Filament\Panel::make()->id('test-panel');
-        \Filament\Facades\Filament::setCurrentPanel($panel);
+        $panel = Panel::make()->id('test-panel');
+        Filament::setCurrentPanel($panel);
     }
     $panel->plugin($plugin);
 
-    expect(\Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource::getModel())->toBe(CustomMenu::class);
-    expect(\Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource::getModel())->toBe(CustomMenuItem::class);
+    expect(MenuResource::getModel())->toBe(CustomMenu::class);
+    expect(MenuItemResource::getModel())->toBe(CustomMenuItem::class);
 });

--- a/tests/Models/MenuItemErrorHandlingTest.php
+++ b/tests/Models/MenuItemErrorHandlingTest.php
@@ -3,6 +3,7 @@
 namespace Biostate\FilamentMenuBuilder\Tests\Models;
 
 use Biostate\FilamentMenuBuilder\Enums\MenuItemType;
+use Biostate\FilamentMenuBuilder\Models\Menu;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
 use Biostate\FilamentMenuBuilder\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -13,7 +14,7 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_route_error_handling(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         $menuItem = MenuItem::factory()->create([
             'menu_id' => $menu->id,
@@ -29,7 +30,7 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_missing_route_parameters_error_handling(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         $menuItem = MenuItem::factory()->create([
             'menu_id' => $menu->id,
@@ -46,7 +47,7 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_url_error_handling(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         // Test with a URL that might cause issues
         $menuItem = MenuItem::factory()->create([
@@ -63,13 +64,13 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_model_error_handling(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         // Use a valid model class but with non-existent ID
         $menuItem = MenuItem::factory()->create([
             'menu_id' => $menu->id,
             'type' => MenuItemType::Model,
-            'menuable_type' => \Biostate\FilamentMenuBuilder\Tests\Models\TestModel::class,
+            'menuable_type' => TestModel::class,
             'menuable_id' => 99999, // Non-existent ID
         ]);
 
@@ -80,10 +81,10 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_model_without_menu_link_error_handling(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         // Create a test model manually
-        $testModel = new \Biostate\FilamentMenuBuilder\Tests\Models\TestModel;
+        $testModel = new TestModel;
         $testModel->name = 'Test Model';
         $testModel->save();
 
@@ -101,7 +102,7 @@ class MenuItemErrorHandlingTest extends TestCase
 
     public function test_successful_link_resolution(): void
     {
-        $menu = \Biostate\FilamentMenuBuilder\Models\Menu::factory()->create();
+        $menu = Menu::factory()->create();
 
         $menuItem = MenuItem::factory()->create([
             'menu_id' => $menu->id,

--- a/tests/Models/MenuItemTest.php
+++ b/tests/Models/MenuItemTest.php
@@ -6,6 +6,7 @@ use Biostate\FilamentMenuBuilder\Enums\MenuItemType;
 use Biostate\FilamentMenuBuilder\Models\Menu;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
 use Biostate\FilamentMenuBuilder\Tests\TestCase;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 
@@ -66,7 +67,7 @@ class MenuItemTest extends TestCase
             'menuable_id' => 1,
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphTo::class, $menuItem->menuable());
+        $this->assertInstanceOf(MorphTo::class, $menuItem->menuable());
     }
 
     public function test_get_menu_name_attribute_without_menuable(): void

--- a/tests/Models/MenuTest.php
+++ b/tests/Models/MenuTest.php
@@ -6,6 +6,7 @@ use Biostate\FilamentMenuBuilder\Models\Menu;
 use Biostate\FilamentMenuBuilder\Models\MenuItem;
 use Biostate\FilamentMenuBuilder\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Sluggable\SlugOptions;
 
 class MenuTest extends TestCase
 {
@@ -54,7 +55,7 @@ class MenuTest extends TestCase
         $menu = new Menu;
         $slugOptions = $menu->getSlugOptions();
 
-        $this->assertInstanceOf(\Spatie\Sluggable\SlugOptions::class, $slugOptions);
+        $this->assertInstanceOf(SlugOptions::class, $slugOptions);
     }
 
     public function test_factory_creation(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Testing\TestResponse;
 use Kalnoy\Nestedset\NestedSetServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -22,7 +23,7 @@ use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 class TestCase extends Orchestra
 {
     /**
-     * @var \Illuminate\Testing\TestResponse|null
+     * @var TestResponse|null
      */
     protected static $latestResponse;
 

--- a/tests/Traits/MenuableTest.php
+++ b/tests/Traits/MenuableTest.php
@@ -5,6 +5,9 @@ namespace Biostate\FilamentMenuBuilder\Tests\Traits;
 use Biostate\FilamentMenuBuilder\Tests\Models\TestModel;
 use Biostate\FilamentMenuBuilder\Tests\Models\TestModelWithTranslations;
 use Biostate\FilamentMenuBuilder\Tests\TestCase;
+use Biostate\FilamentMenuBuilder\Traits\Menuable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class MenuableTest extends TestCase
@@ -16,9 +19,9 @@ class MenuableTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('You need to implement the menuLink method');
 
-        $model = new class extends \Illuminate\Database\Eloquent\Model
+        $model = new class extends Model
         {
-            use \Biostate\FilamentMenuBuilder\Traits\Menuable;
+            use Menuable;
         };
 
         $model->menu_link;
@@ -128,9 +131,9 @@ class MenuableTest extends TestCase
 
     public function test_get_filament_search_option_name_uses_menu_name_accessor(): void
     {
-        $model = new class(['name' => 'ignored']) extends \Illuminate\Database\Eloquent\Model
+        $model = new class(['name' => 'ignored']) extends Model
         {
-            use \Biostate\FilamentMenuBuilder\Traits\Menuable;
+            use Menuable;
 
             protected $fillable = ['name'];
 
@@ -167,7 +170,7 @@ class MenuableTest extends TestCase
     {
         $query = TestModel::filamentSearch('test');
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $query);
+        $this->assertInstanceOf(Builder::class, $query);
     }
 
     public function test_filament_search_with_empty_search_term(): void

--- a/tests/Traits/MenuableTest.php
+++ b/tests/Traits/MenuableTest.php
@@ -123,7 +123,24 @@ class MenuableTest extends TestCase
     {
         $model = new TestModel(['name' => null]);
 
-        $this->assertNull($model->getFilamentSearchOptionName());
+        $this->assertSame('', $model->getFilamentSearchOptionName());
+    }
+
+    public function test_get_filament_search_option_name_uses_menu_name_accessor(): void
+    {
+        $model = new class(['name' => 'ignored']) extends \Illuminate\Database\Eloquent\Model
+        {
+            use \Biostate\FilamentMenuBuilder\Traits\Menuable;
+
+            protected $fillable = ['name'];
+
+            public function getMenuNameAttribute(): string
+            {
+                return 'From Accessor';
+            }
+        };
+
+        $this->assertSame('From Accessor', $model->getFilamentSearchOptionName());
     }
 
     public function test_menuable_trait_can_be_used_on_different_models(): void


### PR DESCRIPTION
## Summary

- Fixes the `null label` error reported in #23 when a `Menuable` model has no `name` column but implements `getMenuNameAttribute()`.
- Untangles two responsibilities that were previously conflated: `getFilamentSearchLabel()` is the **database column** used in the search `WHERE` clause, while `getMenuNameAttribute()` (`menu_name`) is the **display name** shown in the Select.
- Documents `getFilamentSearchLabel()` in the Menuable Trait guide so users know when to override it.

## Root cause

`MenuItemResource` built the menuable Select options with:

```php
$model::all()->pluck($model::getFilamentSearchLabel(), 'id')
```

Default search label is `'name'`, so the pluck queried the `name` column directly, bypassing `getMenuNameAttribute()`. Models without a `name` column produced `null` labels and Filament threw:

```
Filament\Forms\Components\Select::isOptionDisabled():
Argument #2 ($label) must be of type Htmlable|string, null given
```

## Changes

- `src/Filament/Resources/MenuItemResource.php` — replace both `pluck($column, 'id')` calls with `mapWithKeys` driven by `getFilamentSearchOptionName()`, so labels flow through the model's accessor. The search variant now calls `->get()->mapWithKeys(...)` since the previous `Builder::pluck` did not run accessors anyway.
- `src/Traits/Menuable.php` — `getFilamentSearchOptionName()` returns `\$this->menu_name` instead of `\$this->{getFilamentSearchLabel()}`. This is what actually fixes the bug — `getOptionLabelUsing` in the resource also calls this method, so changing only the resource would still leave a null-label path.
- `docs/menuable-trait.md` — adds a *Customizing the Search Column* section explaining when to override `getFilamentSearchLabel()` and clarifying that the display label is independent.
- `tests/Traits/MenuableTest.php` — null-name assertion updated (`TestModel::getMenuNameAttribute()` coalesces to `''`), plus a new test confirming a custom `getMenuNameAttribute()` is what `getFilamentSearchOptionName()` returns.
- `CHANGELOG.md` — adds an `Unreleased` entry.

## Test plan

- [x] `vendor/bin/pest` — full suite passes locally (97 tests, 269 assertions).
- [ ] Manual smoke test: select a menuable model that has no `name` column but defines `getMenuNameAttribute()`; confirm the Select renders without the `isOptionDisabled` TypeError and shows the accessor's value.
- [ ] Verify existing models with a `name` column still render the same labels as before (default behavior unchanged).

Closes #23