### PR TITLE
Harden CI: stop Pint/PHPStan loop and expand test matrix

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest
@@ -18,8 +22,20 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v3
+
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.4
+
+      - name: Verify PHPStan still passes after styling
+        run: ./vendor/bin/phpstan --error-format=github --memory-limit=512M --no-progress
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,21 +6,29 @@ on:
       - '**.php'
       - 'phpstan.neon.dist'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpstan:
-    name: phpstan
+    name: phpstan (P${{ matrix.php }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v3
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan --error-format=github
+        run: ./vendor/bin/phpstan --error-format=github --memory-limit=512M

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -13,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
+        php: [8.2, 8.3, 8.4]
         laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `filament-menu-builder` will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+* Disable Pint's `fully_qualified_strict_types` rule to stop the recurring loop where the auto-styling workflow shortened docblock generic FQCNs without adding the matching `use` import, which then broke PHPStan.
+* The auto-styling workflow now runs PHPStan after Pint and only commits the styling fix if PHPStan still passes — preventing the bot from publishing a broken commit.
+
+### CI
+
+* Expand the test matrix to PHP 8.2 / 8.3 / 8.4 (was 8.2 only).
+* Run PHPStan against PHP 8.2 / 8.3 / 8.4 with an explicit `--memory-limit=512M` so analysis no longer fails opaquely on memory exhaustion.
+* Add `concurrency` groups to all workflows so superseded pushes cancel in-flight runs.
+* `composer analyse` now mirrors CI's memory limit.
+
 ## v5.0.2 - 2026-04-30
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=512M",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"

--- a/pint.json
+++ b/pint.json
@@ -5,6 +5,7 @@
         "concat_space": {
             "spacing": "one"
         },
+        "fully_qualified_strict_types": false,
         "method_argument_space": true,
         "single_trait_insert_per_statement": true,
         "types_spaces": {


### PR DESCRIPTION
## Summary

This PR addresses two recurring CI/process incidents we hit while shipping v5.0.2:

1. **Pint/PHPStan loop.** Six historical "Fix styling" commits on `src/FilamentMenuBuilderPlugin.php` trace back to the same root cause — Pint's `fully_qualified_strict_types` rule shortens docblock generic FQCNs (`class-string<\Foo\Bar>` → `class-string<Bar>`) without adding a `use` import, which then breaks PHPStan. The auto-styling workflow force-pushes the broken state to the PR.
2. **PHP-version coverage gap.** The test matrix was PHP 8.2 only, even though issue #23 was reported on PHP 8.4.20. PHPStan also ran without a memory limit and was prone to opaque crashes locally (default 128 MB).

## Changes

- `pint.json`: disable `fully_qualified_strict_types`. Docblock FQCNs now stay fully qualified, breaking the loop at the source.
- `.github/workflows/fix-php-code-style-issues.yml`: run PHPStan **after** Pint and **before** the auto-commit step, so a Pint-induced PHPStan break aborts the workflow instead of being force-pushed.
- `.github/workflows/run-tests.yml`: expand `php` axis to `[8.2, 8.3, 8.4]`.
- `.github/workflows/phpstan.yml`: same matrix expansion + `--memory-limit=512M`.
- All three workflows: add `concurrency: cancel-in-progress` so superseded pushes cancel in-flight runs.
- `composer.json`: `composer analyse` mirrors CI's memory limit.
- `CHANGELOG.md`: Unreleased entry.

## Test plan

- [x] `vendor/bin/pint --test` passes on all 51 files; `src/FilamentMenuBuilderPlugin.php` is no longer rewritten.
- [x] `composer analyse` succeeds with no errors.
- [x] `vendor/bin/pest` passes (97 tests, 269 assertions).
- [ ] CI matrix shows 12 test jobs (3 PHP × 2 stability × 2 OS) and 3 PHPStan jobs, all green.
- [ ] The styling workflow runs PHPStan on this PR and either passes cleanly or fails *without* force-pushing a broken commit.

No functional code changes in this PR — CI/tooling only. Ready for v5.0.3 once green.