### PR TITLE
Add contributor process docs and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default reviewers for any change.
+#
+# Replace `@Biostate` with a more specific GitHub team or user handle once
+# one is configured (e.g. `@Biostate/filament-menu-builder-maintainers`).
+* @Biostate

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing! A short summary plus the checklist below
+     keeps reviews fast. Delete sections that don't apply. -->
+
+## Summary
+
+<!-- What does this PR do? Link any issues it closes (Closes #123). -->
+
+## Why
+
+<!-- Optional: explain the motivation if it isn't obvious from the summary. -->
+
+## Test plan
+
+<!-- How did you verify this? CI runs the test/PHPStan/Pint matrix
+     automatically; call out any manual steps you took beyond that. -->
+
+- [ ] `composer test` passes locally
+- [ ] `composer analyse` passes locally
+- [ ] `vendor/bin/pint --test` passes locally
+- [ ] Updated `CHANGELOG.md` under `## Unreleased` (if user-visible)
+- [ ] Added or updated tests for the change
+- [ ] Considered backwards compatibility — any soft breaks documented above

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,43 @@
+# Releasing
+
+This package is consumed via Composer / Packagist, so a release is "a git tag pushed to GitHub." Packagist auto-imports tagged versions; a GitHub Release surfaces the changelog on the repo page.
+
+## Versioning
+
+We follow [SemVer](https://semver.org/):
+
+- **Patch** (`5.0.x`) — backwards-compatible bug fixes, internal refactors, CI / tooling.
+- **Minor** (`5.x.0`) — backwards-compatible additions; soft API changes that shouldn't break working installs but are worth flagging in `UPGRADING.md` if it exists.
+- **Major** (`x.0.0`) — breaking changes to the public API.
+
+When in doubt, prefer the larger bump.
+
+## Cutting a release
+
+1. Confirm `main` is green: latest commit on `main` should have all required checks passing (`gh pr checks` or the Actions tab).
+2. Open `CHANGELOG.md` and convert the `## Unreleased` heading to `## vX.Y.Z - YYYY-MM-DD`. Append a `**Full Changelog**` link comparing against the previous tag.
+3. Commit on `main`:
+   ```
+   git commit -m "Update CHANGELOG for vX.Y.Z"
+   git push origin main
+   ```
+4. Create an annotated tag:
+   ```
+   git tag -a vX.Y.Z -m "vX.Y.Z release notes..."
+   git push origin vX.Y.Z
+   ```
+5. Create a GitHub Release on top of the tag (this notifies watchers and is what shows up on the Releases page):
+   ```
+   gh release create vX.Y.Z \
+     --title "vX.Y.Z" \
+     --notes "<release notes — usually the same content as the CHANGELOG entry>"
+   ```
+6. Within a few minutes, Packagist picks up the new tag automatically. Verify at <https://packagist.org/packages/biostate/filament-menu-builder>.
+
+## Merging contributor PRs
+
+We use **merge commits** (not squash, not rebase) so each contributor's history stays attributable. Use `gh pr merge <number> --merge --delete-branch` or the equivalent GitHub UI option.
+
+## Hotfixes
+
+If a critical issue ships, branch off the latest tag (`git checkout -b hotfix/foo vX.Y.Z`), apply the fix, open a PR against `main`, and follow the normal release flow with a patch bump.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+# PHPStan baseline file.
+#
+# Errors listed here are temporarily ignored. Add entries with:
+#   ./vendor/bin/phpstan analyse --generate-baseline
+# and remove them by fixing the underlying code. Currently empty —
+# the suite runs cleanly at level 4 without exceptions.


### PR DESCRIPTION
## Summary

Process scaffolding identified during the v5.0.2 retrospective (no code changes).

- `.github/CODEOWNERS` — default reviewer routing for any path. Currently set to `@Biostate`; can be tightened to a team handle later.
- `.github/pull_request_template.md` — short PR template with summary, test plan, and a checklist (CHANGELOG entry, tests, BC notes) so contributors don't forget the recurring asks.
- `RELEASING.md` — documents the release flow we've been doing implicitly (CHANGELOG → commit on main → annotated tag → `gh release create` → Packagist).
- `phpstan-baseline.neon` — replace 0-byte placeholder with a comment explaining its purpose. The file is referenced from `phpstan.neon.dist` and was confusing to encounter empty.

## Test plan

- [x] `composer analyse` passes locally with the commented baseline.
- [ ] PR template auto-populates on this PR's body (visible to reviewers).
- [ ] CODEOWNERS auto-suggests `@Biostate` once branch protection is configured.

No functional impact on consumers.