### PR TITLE
Make default Menuable::getMenuNameAttribute() null-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to `filament-menu-builder` will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+* The default `Menuable::getMenuNameAttribute()` now returns `(string) ($this->name ?? '')` instead of `$this->name`. Previously, models that did not have a `name` column (or had a null `name` value) raised a `TypeError` when something accessed `$model->menu_name`, because the method declares `: string` return type. The new default coalesces to an empty string, which is strictly safer.
+
 ### Tests
 
 * Add regression coverage for issue #23: a `NamelessMenuable` test fixture that mirrors the exact bug shape (no `name` column, display name computed via `getMenuNameAttribute()`), plus tests that exercise the `MenuItemResource` Select options pipeline. Reverting the v5.0.2 trait fix now causes these tests to fail with `[null, null]` instead of model labels.
+
+### Documentation
+
+* Add an "Upgrading" section to the Menuable Trait guide documenting (a) the v5.0.2 behavioral change to `getFilamentSearchOptionName()` and (b) the v5.0.4 null-safe default for `getMenuNameAttribute()`.
 
 ## v5.0.3 - 2026-04-30
 

--- a/docs/menuable-trait.md
+++ b/docs/menuable-trait.md
@@ -89,3 +89,34 @@ return [
 ## Using in Menu Item Forms
 
 Once you've added these configurations, you can see the menu items in the menu item forms as a select input. This allows you to easily link menu items to your models directly from the Filament admin panel.
+
+## Upgrading
+
+### From <5.0.2
+
+Before 5.0.2, the menu item Select displayed labels by reading the column named by `getFilamentSearchLabel()` directly from the database. Starting in 5.0.2 it routes labels through the `menu_name` accessor (`getMenuNameAttribute()`) instead. The two methods are now independent:
+
+- `getFilamentSearchLabel()` controls the column used in the search `WHERE` clause.
+- `getMenuNameAttribute()` controls the visible label.
+
+If you previously overrode `getFilamentSearchLabel()` to point at a non-`name` column (for example `'title'`) and *didn't* also override `getMenuNameAttribute()`, the Select will now render empty labels instead of the column value. Add a `getMenuNameAttribute()` that returns the same column to restore the old behavior:
+
+```php
+public function getMenuNameAttribute(): string
+{
+    return (string) ($this->title ?? '');
+}
+```
+
+### From <5.0.4
+
+The default `getMenuNameAttribute()` provided by the trait used to return `$this->name` directly. If `$this->name` was null (or the column didn't exist), this raised a `TypeError` at access time because the method declares `: string`. Starting in 5.0.4 the default coalesces to an empty string:
+
+```php
+public function getMenuNameAttribute(): string
+{
+    return (string) ($this->name ?? '');
+}
+```
+
+If you've overridden `getMenuNameAttribute()` in your own models, this change has no effect on you. If you were relying on the default for models without a `name` column, your code now returns `''` instead of throwing — usually a strict improvement, but worth noting if any of your tests assert on the exception.

--- a/src/Traits/Menuable.php
+++ b/src/Traits/Menuable.php
@@ -13,7 +13,7 @@ trait Menuable
 
     public function getMenuNameAttribute(): string
     {
-        return $this->name;
+        return (string) ($this->name ?? '');
     }
 
     public static function getFilamentSearchLabel(): string


### PR DESCRIPTION
## Summary

The default `Menuable::getMenuNameAttribute()` returned `\$this->name` directly. Because the method declares `: string`, any model that didn't have a `name` column (or had a null value in it) raised a `TypeError` the moment something accessed `\$model->menu_name`. This was the symptom one layer above issue #23.

Coalesce to an empty string so the default is strictly safer:

\`\`\`php
public function getMenuNameAttribute(): string
{
    return (string) (\$this->name ?? '');
}
\`\`\`

Same convention `tests/Models/TestModel.php` already uses.

## Compatibility

This is a soft tightening, not a break:

- Models that **already override** `getMenuNameAttribute()` are unaffected.
- Models that **rely on the default** and have a non-null `name` get the same string they got before.
- Models that **rely on the default** and have a null/missing `name` previously raised a `TypeError`; they now get `''`. Any code asserting the exception will need updating, but no code that *worked* before changes behavior.

## Documentation

`docs/menuable-trait.md` gains an "Upgrading" section that covers both this change and the v5.0.2 behavioral change to `getFilamentSearchOptionName()` (the issue #23 fix). Catches users who upgrade from <5.0.2 in one place.

## Test plan

- [x] `composer test` — 100 tests / 274 assertions pass.
- [x] `composer analyse` — no errors.
- [x] `vendor/bin/pint --test` — clean.
- [ ] CI matrix passes across PHP 8.2/8.3/8.4.

Ready for v5.0.4 once green (bundling the test additions from #27 and this change).