### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,22 +18,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*, 13.*]
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
             carbon: 2.*
-          - laravel: 12.*
-            testbench: 10.*
-            carbon: 3.*
-          - laravel: 13.*
-            testbench: 11.*
-            carbon: 3.*
-        exclude:
-          # Laravel 13 requires PHP >= 8.3
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,12 +18,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
             carbon: 2.*
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: 3.*
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: 3.*
+        exclude:
+          # Laravel 13 requires PHP >= 8.3
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "filament/forms": "^5.0",
         "filament/tables": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "kalnoy/nestedset": "^6.0",
+        "kalnoy/nestedset": "^6.0|^7.0",
         "spatie/laravel-sluggable": "^3.6"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #31

## Problem

Installing `biostate/filament-menu-builder:^5.0` on a Laravel 13 project fails to resolve:

```
- kalnoy/nestedset v6.0.7 requires illuminate/support >=7.0,<=12.0
```

`kalnoy/nestedset ^6.0` caps `illuminate/*` at 12.0, so Composer can't satisfy Laravel 13's `illuminate/support` v13.

## Fix

Widen the constraint to `kalnoy/nestedset: ^6.0|^7.0`. nestedset **v7.0.0** requires `illuminate/* >=13.0`; v6 stays for Laravel <=12. Composer picks v7 on Laravel 13 and v6 below — no break for existing users.

Remaining runtime deps already support Laravel 13:
- `filament/* ^5` → `illuminate/contracts ^11.28|^12.0|^13.0`
- `spatie/laravel-sluggable ^3.6` → resolves to 3.8.1 (`^10|^11|^12|^13`)
- `spatie/laravel-package-tools ^1.15` → resolves to 1.93.1 (`^10|^11|^12|^13`)

Verified with `composer update -W --dry-run` — clean resolution, no conflict.

## Note on CI

Testing Laravel 12/13 in the CI matrix requires upgrading the dev toolchain (Pest 2→4, larastan 2→3, phpstan rules 1→2), so it is left as a separate follow-up. This PR keeps the existing Laravel 11 CI matrix and changes only the runtime constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)